### PR TITLE
fixed missing minizip lib

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -44,10 +44,10 @@ version_control:
     - external/minizip:
       type: archive
       no_subdirectory: true
-      url: http://www.winimage.com/zLibDll/unzip11.zip
+      url: http://www.winimage.com/zLibDll/unzip101e.zip
       patches: 
       #WARNING, DO NOT CHANGE THE ORDER OF THE PATCHES
         - [$AUTOPROJ_SOURCE_DIR/minizip.patch, 1]
-        - [$AUTOPROJ_SOURCE_DIR/minizip_unzip.patch, 1]
+#        - [$AUTOPROJ_SOURCE_DIR/minizip_unzip.patch, 1]
       update_cached_file: false
 


### PR DESCRIPTION
seems to be an older version, but http://www.winimage.com/zLibDll/unzip11.zip is not available anymore.

unzip101e already checks  the content of the minizip_unzip.patch file, at least what i could see (could 101e be newer than 11?).

mars .scn files loaded fine on my checkout with unzip 101e.