### PR TITLE
Include the connectors plugin. 

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -78,6 +78,7 @@ in_flavor 'master','stable' do
     mars_package("simulation/mars/plugins/connexion_plugin")
     mars_package("simulation/mars/plugins/VirtualJoystickPlugin")
     mars_package("simulation/mars/plugins/constraint_plugin")
+    mars_package("simulation/mars/plugins/connectors")
     
     mars_package("simulation/mars/doc",:import_package) do |pkg|
         pkg.doc_task do


### PR DESCRIPTION
Otherwise autoproj can not find the dependency.