### PR TITLE
Fix setting of PYTHONPATH for mars/plugins/PythonMars

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -30,7 +30,9 @@ mars_package("simulation/mars/common/graphics/osg_material_manager")
 mars_package("simulation/mars/common/graphics/osg_terrain")
 mars_package("simulation/mars/common/graphics/osg_points")
 mars_package("simulation/mars/plugins/TerrainPlugin")
-mars_package("simulation/mars/plugins/PythonMars")
+mars_package("simulation/mars/plugins/PythonMars") do |pkg|
+    pkg.env_add_path 'PYTHONPATH', File.join(pkg.prefix, "share","PythonMars","python")
+end
 mars_package("simulation/mars/common/gui/data_broker_plotter2")
 cmake_package("simulation/mars_extensions/data_broker_graph_view")
 


### PR DESCRIPTION
@malter At this stage I would also suggest, that you do not install python files into share, but into the lib/pythonXX/site-packages folder