### PR TITLE
[ode16_install] Fix dependency management of ODE 16 and installation, use git

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -102,10 +102,7 @@ in_flavor 'master','stable' do
             "CXXFLAGS=-fPIC -O2 -Wall"
     end
     autotools_package 'simulation/ode-16' do |pkg|
-        def pkg.configure
-            system('cd simulation/ode-16;./bootstrap')
-            super
-        end
+        pkg.using[:autogen] = 'bootstrap'
         pkg.depends_on 'libtool'
         pkg.provides "pkgconfig/ode"
         pkg.configureflags <<

--- a/libs.autobuild
+++ b/libs.autobuild
@@ -102,10 +102,10 @@ in_flavor 'master','stable' do
             "CXXFLAGS=-fPIC -O2 -Wall"
     end
     autotools_package 'simulation/ode-16' do |pkg|
-        def pkg.prepare
+        def pkg.configure
             system('cd simulation/ode-16;./bootstrap')
-	    super
-	end
+            super
+        end
         pkg.depends_on 'libtool'
         pkg.provides "pkgconfig/ode"
         pkg.configureflags <<

--- a/manifests/simulation/ode-16.xml
+++ b/manifests/simulation/ode-16.xml
@@ -1,0 +1,7 @@
+<package>
+    <description brief="ODE">
+       Open Dynamics Engine
+    </description>
+    <depend package="libtool" />
+    <depend package="automake" />
+</package>

--- a/mars.osdeps
+++ b/mars.osdeps
@@ -4,6 +4,9 @@ libtool:
     opensuse: libtool
     darwin: glibtool
 
+automake:
+    debian, ubuntu: [automake]
+
 zlib: 
     debian,ubuntu: zlib1g-dev
     opensuse: zlib-devel

--- a/source.yml
+++ b/source.yml
@@ -46,8 +46,9 @@ version_control:
       update_cached_file: false
 
     - simulation/ode-16:
-      type: archive
-      url: https://bitbucket.org/odedevs/ode/downloads/ode-0.16.tar.gz
+      type: git
+      url: https://bitbucket.org/odedevs/ode.git
+      tag: 0.16
       patches:
       #WARNING, DO NOT CHANGE THE ORDER OF THE PATCHES
         - $AUTOPROJ_SOURCE_DIR/ode-0.16-lambda.patch
@@ -55,7 +56,6 @@ version_control:
         - $AUTOPROJ_SOURCE_DIR/ode-0.16-abort.patch
         #- $AUTOPROJ_SOURCE_DIR/ode-0.12-osx.patch
         - $AUTOPROJ_SOURCE_DIR/ode-0.16-heightfield.patch
-      update_cached_file: false
 
     - external/minizip:
       type: archive


### PR DESCRIPTION
Since the dependencies libtool and automake are not dynamic and needed for the bootstrap of ODE, they have to be installed in a previous step to the bootstrap. For that, the manifest is needed and the bootstrap is moved to the configure step, so that the update step has the chance to finish installing the dependencies.

See the section on "Defining Dependencies" in this [Rock documentation link](https://www.rock-robotics.org/documentation/autoproj/advanced/autobuild.html)

@malter 